### PR TITLE
Fix "ValueError: Object arrays cannot be loaded when allow_pickle=False"

### DIFF
--- a/Detector.ipynb
+++ b/Detector.ipynb
@@ -78,7 +78,7 @@
    "source": [
     "Base = \"processed_images/\"\n",
     "if path.exists(\"change.npy\"):\n",
-    "    change_cam,loc,Cstat = np.load(\"change.npy\")\n",
+    "    change_cam,loc,Cstat = np.load(\"change.npy\",allow_pickle=True)\n",
     "else:\n",
     "    change_cam, loc,Cstat = change_detect(Base)\n",
     "    np.save(\"change.npy\",[change_cam,loc,Cstat])"
@@ -319,7 +319,7 @@
     "\n",
     "\n",
     "if path.exists(\"result2.npy\"):\n",
-    "    Times2, Stat2 = np.load(\"result2.npy\")\n",
+    "    Times2, Stat2 = np.load(\"result2.npy\",allow_pickle=True)\n",
     "else:\n",
     "    Times2, Stat2 = backtrack1(Bounds2,Base)\n",
     "    np.save(\"result2.npy\",[Times2,Stat2])"

--- a/Detector.py
+++ b/Detector.py
@@ -49,7 +49,7 @@ AT = extract_cases(All_Cords)
 
 Base = "processed_images/"
 if path.exists("change.npy"):
-    change_cam,loc,Cstat = np.load("change.npy")
+    change_cam,loc,Cstat = np.load("change.npy",allow_pickle=True)
 else:
     change_cam, loc,Cstat = change_detect(Base)
     np.save("change.npy",[change_cam,loc,Cstat])
@@ -158,7 +158,7 @@ Base = "ori_images/"
 
 
 if path.exists("result2.npy"):
-    Times2, Stat2 = np.load("result2.npy")
+    Times2, Stat2 = np.load("result2.npy",allow_pickle=True)
 else:
     Times2, Stat2 = backtrack1(Bounds2,Base)
     np.save("result2.npy",[Times2,Stat2])


### PR DESCRIPTION
NOTE: Please _rebase_ this into _master_ instead of choosing the _merge_ option to avoid generating an extra commit.

![ValueError](https://user-images.githubusercontent.com/31109774/113935957-2c266f80-97c5-11eb-912c-569e26f42022.png)

For more info: [Unpickling while loading requires explicit opt-in](https://numpy.org/devdocs/release/1.16.3-notes.html#unpickling-while-loading-requires-explicit-opt-in)
